### PR TITLE
Modified sopm

### DIFF
--- a/DashboardMOTDPlus.sopm
+++ b/DashboardMOTDPlus.sopm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <otrs_package version="1.0">
-    <Name>Dashboard MOTD Plus</Name>
+    <Name>DashboardMOTDPlus</Name>
     <Version>0.0.2</Version>
     <Framework>2.4.x</Framework>
     <Vendor>Daniel Obee</Vendor>


### PR DESCRIPTION
I removed the whitespaces from the sopm because this is the name of the package build by the otrs.PackageManager. If you accept this pull request opmzone can build your opm successful :+1: 
