### PR TITLE
Updated sopm-file for OTRS 3.3

### DIFF
--- a/DashboardMOTDPlus.sopm
+++ b/DashboardMOTDPlus.sopm
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <otrs_package version="1.0">
     <Name>DashboardMOTDPlus</Name>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Framework>3.0.x</Framework>
     <Framework>3.1.x</Framework>
     <Framework>3.2.x</Framework>
+    <Framework>3.3.x</Framework>
     <Vendor>Daniel Obee</Vendor>
     <URL>http://33achtzig.de/</URL>
     <License>GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007</License>
+    <ChangeLog Version="1.0.2" Date="2014-03-07 17:48:00">Upgrade for OTRS 3.3</ChangeLog>
     <ChangeLog Version="1.0.1" Date="2013-02-07 14:28:00">Upgrade for OTRS 3.x</ChangeLog>
     <ChangeLog Version="0.0.2" Date="2010-07-23 09:47:00">Fixed bug that caused crash of dashboard. Set default Response to 1.</ChangeLog>
     <ChangeLog Version="0.0.1" Date="2010-07-22 16:17:51">Initial Release</ChangeLog>


### PR DESCRIPTION
Auch auf 3.3.5 getestet - und funktioniert wunderbar ;-)
